### PR TITLE
Added ADC delay for reliable read of high-impedance inputs.

### DIFF
--- a/Attiny85/platformio.ini
+++ b/Attiny85/platformio.ini
@@ -4,7 +4,7 @@
 ; home_dir = C:\platformio
 
 [platformio]
-default_envs = attiny85  ; attiny45 
+default_envs = attiny45  ; attiny45
 
 [env:attiny85]
 platform = atmelavr@3.3.0
@@ -13,7 +13,7 @@ framework = arduino
 board_build.mcu = attiny85
 board_build.f_cpu  = 1000000L
 
-build_flags = -Wall
+build_flags = -Wall -Os
 ; Логгирование 
 ; ============
 ; TX пин - Счетчик 1 (PB3) будет 9600 8N1
@@ -53,7 +53,7 @@ framework = arduino
 board_build.mcu = attiny45
 board_build.f_cpu  = 1000000L
 
-build_flags = -Wall
+build_flags = -Wall -Os
 upload_port = COM5
 
 upload_protocol = usbasp

--- a/Attiny85/platformio.ini
+++ b/Attiny85/platformio.ini
@@ -7,7 +7,7 @@
 default_envs = attiny45  ; attiny45
 
 [env:attiny85]
-platform = atmelavr@3.3.0
+platform = atmelavr@3.4.0
 board = attiny85
 framework = arduino
 board_build.mcu = attiny85
@@ -47,7 +47,7 @@ upload_flags =
 
 
 [env:attiny45]
-platform = atmelavr@3.3.0
+platform = atmelavr@3.4.0
 board = attiny45
 framework = arduino
 board_build.mcu = attiny45

--- a/Attiny85/src/SlaveI2C.cpp
+++ b/Attiny85/src/SlaveI2C.cpp
@@ -6,7 +6,7 @@
 #include <Wire.h>
 
 extern struct Header info;
-extern uint32_t wakeup_period;
+extern volatile uint32_t wakeup_period;
 
 /* Static declaration */
 uint8_t SlaveI2C::txBufferPos = 0;

--- a/Attiny85/src/counter.h
+++ b/Attiny85/src/counter.h
@@ -16,8 +16,8 @@
 #define LIMIT_NAMUR_OPEN   800   // < 800 - намур разомкнут
                                  // > - обрыв
 
-#define TRIES_CLOSE 1  //Минимальная длительность состояния "1"
-#define TRIES_OPEN  3  //Минимальная длительность состояния "0"
+#define TRIES_CLOSE 2   //Минимальная длительность состояния "1"
+#define TRIES_OPEN  24  //Минимальная длительность состояния "0"
 
 enum CounterState_e
 {

--- a/Attiny85/src/counter.h
+++ b/Attiny85/src/counter.h
@@ -50,7 +50,9 @@ struct CounterB
     inline uint16_t aRead() 
     {
         PORTB |= _BV(_pin);      // INPUT_PULLUP
-        uint16_t ret = analogRead(_apin); // в TinyCore там работа с битами, оптимально
+        analogRead(_apin);   // Switch MUX to channel and discard the read
+        delayMicroseconds(1000);    // Wait for ADC S/H capacitor to charge
+        uint16_t ret = analogRead(_apin); // Read ADC
         PORTB &= ~_BV(_pin);     // INPUT
         return ret;
     }

--- a/Attiny85/src/main.cpp
+++ b/Attiny85/src/main.cpp
@@ -143,15 +143,15 @@ inline void counting() {
 
 	if (counter0.is_impuls()) {
 		info.data.value0++;	  //нужен т.к. при пробуждении запрашиваем данные
-		info.adc.adc0 = counter0.adc;		
-		info.states.state0 = counter0.state;
+		info.adc.adc0 = counter0.closed_adc;
+		info.states.state0 = counter0.stable_state;
 		storage.add(info.data);
 	}
 #ifndef LOG_ON
 	if (counter1.is_impuls()) {
 		info.data.value1++;
-		info.adc.adc1 = counter1.adc;
-		info.states.state1 = counter1.state;
+		info.adc.adc1 = counter1.closed_adc;
+		info.states.state1 = counter1.stable_state;
 		storage.add(info.data);
 
 		//delayMicroseconds(65000);

--- a/Attiny85/src/main.cpp
+++ b/Attiny85/src/main.cpp
@@ -17,10 +17,13 @@
 #endif
 
 
-#define FIRMWARE_VER 22    // Передается в ESP и на сервер в данных.
+#define FIRMWARE_VER 23    // Передается в ESP и на сервер в данных.
   
 /*
 Версии прошивок 
+
+23 - 2021.11.16 - svpcom
+        1. Fix impulse counting
 
 22 - 2021.07.13 - dontsovcmc
 	1. переписана работа с watchdog: чип перезагрузится в случае сбоя
@@ -116,7 +119,7 @@ struct Header info = {FIRMWARE_VER, 0, 0, 0, 0, WATERIUS_2C,
 					    0, 0
 					 };
 
-uint32_t wakeup_period;
+volatile uint32_t wakeup_period;
 
 
 //Кольцевой буфер для хранения показаний на случай замены питания или перезагрузки
@@ -174,7 +177,7 @@ void setup() {
 	info.service = MCUSR; // причина перезагрузки
 	MCUSR = 0;            // без этого не работает после перезагрузки по watchdog
 	wdt_disable();
-    wdt_enable(WDTO_250MS);
+	wdt_enable(WDTO_250MS);
 	interrupts(); 
 
 	set_sleep_mode( SLEEP_MODE_PWR_DOWN );
@@ -238,7 +241,7 @@ void loop() {
 
 	esp.power(true);
 	LOG(F("ESP turn on"));
-	
+
 	while (!slaveI2C.masterGoingToSleep() && !esp.elapsed(wake_up_limit)) {
 		
 		wdt_reset(); 
@@ -246,7 +249,12 @@ void loop() {
 		info.voltage = readVcc();   // Текущее напряжение
 		counting();
 
-		delayMicroseconds(65000);
+		delayMicroseconds(62500u);
+		delayMicroseconds(62500u);
+		wdt_reset();
+
+		delayMicroseconds(62500u);
+		delayMicroseconds(62500u);
 
 		if (button.wait_release() > LONG_PRESS_MSEC) {  //wdt_reset внутри wait_release
 			break; // принудительно выключаем


### PR DESCRIPTION
When reading inputs with impedance > 10k some additional delay is needed to allow ADC to charge its internal capacitors.
See for reference: https://github.com/arduino/Arduino/issues/5646