### PR TITLE
Дублирование переменных при формировании object_id

### DIFF
--- a/ESP8266/src/ha/discovery_entity.cpp
+++ b/ESP8266/src/ha/discovery_entity.cpp
@@ -60,8 +60,7 @@ String build_entity_discovery(const char *mqtt_topic,
     String unique_id = uniqueId_prefix + "-" + entity_id;
     entity[F("uniq_id")] = unique_id.c_str(); // unique_id
 
-    String object_id = unique_id;
-    entity[F("obj_id")] = object_id.c_str(); // object_id
+    entity[F("obj_id")] = unique_id.c_str(); // object_id
 
     entity[F("stat_t")] = mqtt_topic; // state_topic
 


### PR DESCRIPTION
В методе descovery переменная object_id совпадает с unique_id.
Пустые тела функций конструктора и деструктора заменены на = default;
Исправлен расчет усредненного напряжения.