### PR TITLE
Изменение организации хранения данных в eeprom

### DIFF
--- a/ESP8266/src/config.cpp
+++ b/ESP8266/src/config.cpp
@@ -18,7 +18,7 @@
 // Сохраняем конфигурацию в EEPROM
 void store_config(const Settings &sett)
 {
-    uint16_t crc = get_checksum(sett);
+    uint16_t crc = get_checksum((uint8_t*)&sett,sizeof(sett)-2);
     EEPROM.begin(sizeof(sett) + sizeof(crc));
     EEPROM.put(0, sett);
     EEPROM.put(sizeof(sett), crc);
@@ -45,7 +45,7 @@ bool load_config(Settings &sett)
     EEPROM.get(sizeof(tmp_sett), crc);
     EEPROM.end();
 
-    uint16_t calculated_crc = get_checksum(tmp_sett);
+    uint16_t calculated_crc = get_checksum((uint8_t*)&tmp_sett,sizeof(tmp_sett)-2);
     if (crc == calculated_crc)
     {
         sett = tmp_sett;

--- a/ESP8266/src/config.cpp
+++ b/ESP8266/src/config.cpp
@@ -18,10 +18,12 @@
 // Сохраняем конфигурацию в EEPROM
 void store_config(const Settings &sett)
 {
-    uint16_t crc = get_checksum((uint8_t*)&sett,sizeof(sett)-2);
-    EEPROM.begin(sizeof(sett) + sizeof(crc));
-    EEPROM.put(0, sett);
-    EEPROM.put(sizeof(sett), crc);
+    eepromCRC eecrc;
+    eecrc.size=sizeof(Settings);
+    eecrc.crc = get_checksum((uint8_t*)&sett, eecrc.size);
+    EEPROM.begin(sizeof(eepromCRC) + sizeof(Settings));
+    EEPROM.put(0, eecrc);
+    EEPROM.put(sizeof(eepromCRC), sett);
 
     if (!EEPROM.commit())
     {
@@ -29,7 +31,7 @@ void store_config(const Settings &sett)
     }
     else
     {
-        LOG_INFO(F("Config stored OK crc=") << crc);
+        LOG_INFO(F("Config stored OK crc=") << eecrc.crc);
     }
     EEPROM.end();
 }

--- a/ESP8266/src/config.h
+++ b/ESP8266/src/config.h
@@ -7,6 +7,11 @@
 
 #include "setup.h"
 
+struct eepromCRC{
+    uint16_t crc;
+    uint16_t size;
+};
+
 /* Сохраняем конфигурацию в EEPROM */
 extern void store_config(const Settings &sett);
 

--- a/ESP8266/src/utils.cpp
+++ b/ESP8266/src/utils.cpp
@@ -52,17 +52,13 @@ String get_mac_address_hex()
  * @param  sett настройки программы
  * @return возвращет чексуму объекта настроек
  */
-uint16_t get_checksum(const Settings &sett)
+uint16_t get_checksum(const uint8_t *buf, uint16_t count, uint16_t crc)
 {
-	uint8_t *buf = (uint8_t *)&sett;
-	uint16_t crc = 0xffff, poly = 0xa001;
-	uint16_t i = 0;
-	uint16_t len = sizeof(sett) - 2;
-
-	for (i = 0; i < len; i++)
+	uint16_t poly = 0xa001;
+	while (count--)
 	{
-		crc ^= buf[i];
-		for (uint8_t j = 0; j < 8; j++)
+		crc ^= *buf++;
+		for (uint8_t j = 8; j ; j--)
 		{
 			if (crc & 0x01)
 			{

--- a/ESP8266/src/utils.h
+++ b/ESP8266/src/utils.h
@@ -22,7 +22,7 @@ extern String get_ap_name();
 
 extern String get_mac_address_hex();
 
-extern uint16_t get_checksum(const Settings &sett);
+extern uint16_t get_checksum(const uint8_t *buf, uint16_t count, uint16_t crc=0xffff);
 
 extern String get_proto(const String &url);
 


### PR DESCRIPTION
В первых 4х байтах хранится контрольная сумма и длина по которой посчитана контрольная сумма. При увеличении размера структуры, контрольная сумма для старого объекта будет посчитана корректно. По разности размеров в eeprom и размера структуры можно безопасно инициализировать новые поля.