### PR TITLE
Сброс кэша быстрого коннекта (wifi_channel/bssid) при смене SSID/пароля

### DIFF
--- a/ESP8266/platformio.ini
+++ b/ESP8266/platformio.ini
@@ -17,7 +17,7 @@ extra_configs = secrets.ini
 platform_packages = platformio/tool-scons@~4.40801.0
 
 [env]
-firmware_version = "\"2.0.44\""
+firmware_version = "\"2.0.45\""
 
 [libraries]
 arduinojson = ArduinoJson@7.3.1

--- a/ESP8266/src/portal/active_point_api.cpp
+++ b/ESP8266/src/portal/active_point_api.cpp
@@ -731,10 +731,18 @@ void applyNonCheckBoxParameter(const AsyncWebParameter *p, JsonObject &errorsObj
     else if (name == FPSTR(PARAM_SSID))
     {
         save_param(p, sett.wifi_ssid, WIFI_SSID_LEN, errorsObj);
+        // Сброс кэша быстрого коннекта: канал/BSSID от прошлого роутера
+        // становятся неактуальны при смене сети — иначе первый коннект уходит
+        // на старый канал (в AP_STA портале это ещё и роняет телефон).
+        sett.wifi_channel = 0;
+        memset(sett.wifi_bssid, 0, sizeof(sett.wifi_bssid));
     }
     else if (name == FPSTR(PARAM_PASSWORD))
     {
         save_param(p, sett.wifi_password, WIFI_PWD_LEN, errorsObj, false);
+        // См. комментарий выше: смена пароля тоже сбрасывает кэш коннекта.
+        sett.wifi_channel = 0;
+        memset(sett.wifi_bssid, 0, sizeof(sett.wifi_bssid));
     }
 
     else if (name == FPSTR(PARAM_WIFI_PHY_MODE))


### PR DESCRIPTION
## Проблема

Пользователи сообщали: при смене роутера или смене пароля текущего роутера Ватериус не может подключиться к Wi-Fi.

## Причина

Ватериус кэширует `wifi_channel`/`wifi_bssid` последнего успешного подключения для быстрого коннекта. Но путь сохранения настроек через веб (`applyNonCheckBoxParameter`) при смене SSID/пароля писал только `wifi_ssid`/`wifi_password`, **не сбрасывая канал/BSSID старого роутера**.

В результате первая попытка `WiFi.begin(ssid, password, wifi_channel, wifi_bssid)` уходила на старый канал/BSSID. Для развёрнутого устройства это обычно вытягивала 2-я попытка (полный скан), а в портальном режиме `WIFI_AP_STA` softAP поднят на старом канале — при переходе станции на новый канал softAP насильно перескакивает, роняя телефон пользователя с портала → в браузере «не удалось подключиться».

Заодно это делало мёртвой логику `channel_changed` в `post_api_save_connect` (значение снималось до `applySettings`, который канал не менял → всегда `false`).

## Фикс

При сохранении `PARAM_SSID`/`PARAM_PASSWORD` сбрасываем `wifi_channel = 0` и обнуляем `wifi_bssid`. Первый коннект идёт полным сканом; актуальный канал сохранится после успешного подключения (`wifi_helpers.cpp`). Канал нужен только для обычной работы, поэтому безусловный сброс при перенастройке безопасен.

Версия прошивки: 2.0.44 → 2.0.45.

## Проверка

- Сборка `esp01_1m` и `waterius_2` — успешно.
- Прошито и проверено на живом ESP-01 (firmware + LittleFS).
- Native-тесты (`pio test -e native`) покрывают только парсинг OTA-URL; данный handler завязан на `AsyncWebServerRequest`/`Settings` и юнит-тестом в текущем харнессе не покрывается.

🤖 Generated with [Claude Code](https://claude.com/claude-code)