### PR TITLE
Публикация симулятора с dev: настройка окружения github-pages

### DIFF
--- a/.github/workflows/simulator-deploy.yml
+++ b/.github/workflows/simulator-deploy.yml
@@ -1,9 +1,10 @@
 # Публикация симулятора портала на GitHub Pages.
 #
-# Перед первым запуском в настройках репозитория нужно включить Pages:
-# Settings -> Pages -> Build and deployment -> Source: GitHub Actions,
-# и там же указать Custom domain (см. DOMAIN ниже) плюс Enforce HTTPS.
-# Без HTTPS не заработает service worker, а без него - весь симулятор.
+# Настройки репозитория, без которых не поедет (подробности - simulator/README.md):
+# Settings -> Pages -> Source: GitHub Actions, там же Custom domain (см. DOMAIN ниже)
+# и Enforce HTTPS - без него не заработает service worker, а с ним и симулятор.
+# Settings -> Environments -> github-pages -> Deployment branches: разрешить dev,
+# иначе job падает за три секунды, не начав шагов.
 name: simulator-deploy
 
 on:

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -102,28 +102,28 @@ ELECTRONIC_HIGH и NONE. Через эту функцию проходит `vali
 
 ## Публикация
 
+Симулятор живёт на **https://firmware-simulator.waterius.ru** — публикует
+`.github/workflows/simulator-deploy.yml`: пуш в `dev`, затрагивающий портал или
+симулятор, гоняет проверки, собирает `dist/` и выкладывает на GitHub Pages. Поддомен
+задан переменной `DOMAIN` в начале workflow.
+
 Симулятору нужны две вещи: **корень домена** и **HTTPS**. Корень — потому что страницы
 ссылаются на `/static/…` и `/images/…` абсолютными путями, а область видимости service
 worker ограничена его каталогом. HTTPS — потому что вне `localhost` браузер не даст
 зарегистрировать service worker, без которого не работает ничего.
 
-Публикует `.github/workflows/simulator-deploy.yml`: на пуш в `dev`, затрагивающий
-симулятор или портал, он собирает `dist/` и выкладывает на GitHub Pages. Поддомен задан
-в `DOMAIN` в начале файла.
+Как это настроено — на случай, если понадобится повторить или перенести:
 
-Что нужно сделать один раз, руками:
-
-1. **Settings → Pages → Build and deployment → Source: GitHub Actions.** Пока это не
-   включено, деплой падает с «Pages is not enabled».
-2. **DNS: CNAME-запись** `firmware-simulator` → `dontsovcmc.github.io.` (с точкой на
-   конце, если панель её требует). Обычная запись у регистратора домена waterius.ru.
-3. **Settings → Pages → Custom domain**: `firmware-simulator.waterius.ru`, сохранить.
-   GitHub проверит DNS — если запись ещё не разошлась, покажет ошибку, надо подождать и
-   нажать проверку ещё раз.
-4. Когда GitHub выпустит сертификат (обычно минуты, иногда до часа), включить там же
-   **Enforce HTTPS**.
-5. Запустить публикацию: вкладка Actions → simulator-deploy → **Run workflow**. Дальше
-   она пойдёт сама на каждое изменение портала в `dev`.
+1. **Settings → Pages → Build and deployment → Source: GitHub Actions.**
+2. **DNS: CNAME** `firmware-simulator` → `dontsovcmc.github.io.` У зоны waterius.ru есть
+   wildcard `*.waterius.ru` → `prod-02`, поэтому запись нужна именно явная: она
+   перебивает wildcard.
+3. **Settings → Pages → Custom domain**: `firmware-simulator.waterius.ru`. GitHub
+   проверяет DNS в момент сохранения, так что порядок с шагом 2 не переставить.
+4. Когда GitHub выпустит сертификат (минуты, изредка до часа) — **Enforce HTTPS** там же.
+5. **Разрешить деплой с `dev`:** Settings → Environments → `github-pages` → Deployment
+   branches. По умолчанию окружение пускает только ветку по умолчанию (`master`), а
+   публикуемся мы с `dev`. Симптом — job падает за три секунды, не начав шагов.
 
 Свой nginx подходит не хуже: `root .../simulator/dist;` на поддомене с сертификатом,
 деплой чем удобно. Содержимое `dist/` — обычные файлы, бэкенда нет.


### PR DESCRIPTION
Симулятор опубликован: **https://firmware-simulator.waterius.ru**

Первый деплой после мержа #391 упал — окружение `github-pages` по умолчанию пускает деплой только с ветки по умолчанию (`master`), а публикуемся мы с `dev`. Симптом неприятный: job падает за три секунды, не начав ни одного шага, логов нет. Ветка `dev` в окружение добавлена, деплой перезапущен и прошёл.

Здесь — только документация: пять шагов настройки в `simulator/README.md` и то же самое кратко в шапке workflow. Отдельно записана явная DNS-запись: у зоны waterius.ru есть wildcard `*.waterius.ru` → `prod-02`, и без явного CNAME на `dontsovcmc.github.io.` GitHub домен не признаёт.

🤖 Generated with [Claude Code](https://claude.com/claude-code)