### PR TITLE
Пульт симулятора в стиле портала

### DIFF
--- a/simulator/src/index.html
+++ b/simulator/src/index.html
@@ -15,18 +15,21 @@
 <main>
     <section class="card">
         <h2>Портал</h2>
-        <p class="note">Страницы открываются в соседней вкладке — они те же, что лежат в прошивке.</p>
-        <div class="links" id="links"></div>
+        <a class="btn" href="/index.html" target="waterius-portal">Ватериус</a>
+        <ul class="pages" id="links"></ul>
     </section>
 
     <section class="card">
         <h2>Сеанс</h2>
         <div class="row">
-            <button data-cmd="button">Нажать кнопку Ватериуса</button>
-            <button data-cmd="reset" class="danger">Сброс к заводским</button>
-            <button id="refresh">Обновить страницу портала</button>
+            <button class="btn btn-sm" data-cmd="button">Нажать кнопку Ватериуса</button>
+            <button class="btn btn-sm btn2" id="refresh">Обновить портал</button>
+            <button class="btn btn-sm btn-red" data-cmd="reset">Сброс к заводским</button>
         </div>
-        <label class="check"><input type="checkbox" id="auto-refresh"> обновлять портал после каждого действия</label>
+        <div class="toggle">
+            <input type="checkbox" id="auto-refresh">
+            <label for="auto-refresh">обновлять портал после каждого действия</label>
+        </div>
         <p class="note" id="session-note"></p>
     </section>
 
@@ -38,10 +41,16 @@
     <section class="card">
         <h2>attiny</h2>
         <div class="row">
-            <label>версия <input type="number" id="attiny-version" min="0" max="255"></label>
-            <label>напряжение, мВ <input type="number" id="attiny-voltage" min="0" max="5000" step="50"></label>
-            <label class="check"><input type="checkbox" id="attiny-link"> есть связь по i2c</label>
-            <label class="check"><input type="checkbox" id="esp-restarted"> ЕСП перезагрузилась внештатно</label>
+            <label class="field">версия <input type="number" id="attiny-version" min="0" max="255"></label>
+            <label class="field">напряжение, мВ <input type="number" id="attiny-voltage" min="0" max="5000" step="50"></label>
+        </div>
+        <div class="toggle">
+            <input type="checkbox" id="attiny-link">
+            <label for="attiny-link">есть связь по i2c</label>
+        </div>
+        <div class="toggle">
+            <input type="checkbox" id="esp-restarted">
+            <label for="esp-restarted">ЕСП перезагрузилась внештатно</label>
         </div>
         <p class="note">Без связи страницы входов покажут ошибку 7, а сохранение типа входа — ошибку 16.
         Версия ниже 41 прячет пороги тревог: их считает attiny. Внештатная перезагрузка даёт плашку на главной.</p>
@@ -50,7 +59,7 @@
     <section class="card">
         <h2>Wi-Fi</h2>
         <div class="row">
-            <label>чем закончится подключение
+            <label class="field">чем закончится подключение
                 <select id="wifi-outcome">
                     <option value="connected">успешно</option>
                     <option value="wrong_password">неверный пароль</option>
@@ -60,12 +69,12 @@
                     <option value="idle">код 0</option>
                 </select>
             </label>
-            <label>статус сейчас <input type="text" id="wifi-status" readonly></label>
+            <label class="field">статус сейчас <input type="text" id="wifi-status" readonly></label>
         </div>
         <label class="block">сети для списка — по строке «имя, уровень 1..4, канал»
-            <textarea id="wifi-networks" rows="4"></textarea>
+            <textarea id="wifi-networks" rows="3"></textarea>
         </label>
-        <button id="wifi-save">Применить сети</button>
+        <button class="btn btn-sm btn2" id="wifi-save" style="margin-top:8px">Применить сети</button>
     </section>
 
     <section class="card wide">

--- a/simulator/src/sim/pult.css
+++ b/simulator/src/sim/pult.css
@@ -1,114 +1,150 @@
+/*
+ * Стиль пульта: тот же язык, что у портала прошивки (ESP8266/data/static/style.css)
+ * и у личного кабинета - синий 1655F5, красный F53410, границы E6E9F1, поля F3F6FE,
+ * Roboto, скругление 8. Стили не переиспользуются напрямую: у портала вёрстка под
+ * экран телефона с фиксированной колонкой 360px, пульту нужна сетка карточек.
+ */
 :root {
-    --bg: #11161c;
-    --card: #1a2129;
-    --line: #2a343f;
-    --text: #e6edf3;
-    --muted: #8b9aab;
-    --accent: #4aa3df;
-    --danger: #d9534f;
+    --accent: #1655f5;
+    --accent-dark: #06277b;
+    --accent-bg: #ebf2fe;
+    --danger: #f53410;
+    --bg: #f5f7fa;
+    --surface: #fff;
+    --border: #e6e9f1;
+    --field: #f3f6fe;
+    --text: #232323;
+    --muted: #5b7795;
+    --disabled: #c3bdbd;
 }
 
-* { box-sizing: border-box; }
+* { margin: 0; padding: 0; box-sizing: border-box; font-family: Roboto, Helvetica, sans-serif; }
 
-body {
-    margin: 0;
-    padding: 0 0 40px;
-    background: var(--bg);
-    color: var(--text);
-    font: 15px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif;
-}
+body { background: var(--bg); color: var(--text); font-size: 14px; line-height: 20px; }
+
+a { color: var(--accent); text-decoration: none; transition: .3s; }
+a:hover { color: var(--danger); }
 
 header {
-    padding: 20px 24px;
-    border-bottom: 1px solid var(--line);
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 16px 24px;
 }
 
-h1 { margin: 0; font-size: 20px; }
-h2 { margin: 0 0 12px; font-size: 16px; }
+h1 { font-size: 20px; line-height: 28px; font-weight: 700; }
+h2 { font-size: 16px; line-height: 24px; font-weight: 700; margin-bottom: 12px; }
+h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
 
-.status { margin: 6px 0 0; color: var(--muted); font-size: 13px; }
+.status { color: var(--muted); font-size: 12px; line-height: 16px; margin-top: 4px; }
 .status.err { color: var(--danger); }
 
 main {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 16px;
-    padding: 16px 24px;
-    max-width: 1200px;
+    padding: 16px 24px 32px;
+    max-width: 1180px;
 }
 
 .card {
-    background: var(--card);
-    border: 1px solid var(--line);
+    background: var(--surface);
+    border: 1px solid var(--border);
     border-radius: 8px;
     padding: 16px;
 }
 
 .card.wide { grid-column: 1 / -1; }
 
-.note { margin: 8px 0 0; color: var(--muted); font-size: 13px; }
+.note { color: var(--muted); font-size: 12px; line-height: 16px; margin-top: 8px; }
 
 .row { display: flex; flex-wrap: wrap; gap: 8px; align-items: flex-end; }
 
-label { display: inline-flex; flex-direction: column; gap: 4px; font-size: 13px; color: var(--muted); }
-label.block { display: flex; margin-top: 12px; }
-label.check { flex-direction: row; align-items: center; gap: 8px; margin-top: 12px; }
+/* поля */
+label.field { display: flex; flex-direction: column; gap: 4px; font-size: 12px; color: var(--muted); }
+label.block { display: block; margin-top: 12px; font-size: 12px; color: var(--muted); }
 
 input, select, textarea {
-    background: #0d1319;
+    font-size: 14px;
     color: var(--text);
-    border: 1px solid var(--line);
-    border-radius: 6px;
-    padding: 7px 9px;
-    font: inherit;
-    min-width: 80px;
+    background: var(--field);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    height: 36px;
+    padding: 0 8px;
+    transition: .3s;
+    min-width: 90px;
 }
 
-textarea { width: 100%; resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; }
+input:focus, select:focus, textarea:focus { border-color: var(--accent); outline: 0; }
+input[readonly] { color: var(--muted); }
 
-input[type=checkbox] { min-width: 0; width: 16px; height: 16px; }
+textarea {
+    width: 100%;
+    height: auto;
+    padding: 8px;
+    line-height: 18px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12px;
+    resize: vertical;
+    margin-top: 4px;
+}
 
-button {
+/* кнопки */
+.btn {
+    display: block;
+    width: 100%;
+    height: 40px;
+    line-height: 38px;
+    text-align: center;
     background: var(--accent);
-    color: #06121c;
-    border: 0;
-    border-radius: 6px;
-    padding: 8px 14px;
-    font: inherit;
-    font-weight: 600;
+    color: #fbf3f3;
+    font-size: 16px;
+    border: 1px solid var(--accent);
+    border-radius: 8px;
     cursor: pointer;
+    transition: .3s;
 }
+.btn:hover { background: var(--accent-dark); border-color: var(--accent-dark); color: #fbf3f3; }
 
-button.danger { background: var(--danger); color: #fff; }
-button.ghost { background: transparent; color: var(--accent); border: 1px solid var(--line); font-weight: 400; }
-button:disabled { opacity: .5; cursor: default; }
+.btn-sm { width: auto; height: 32px; line-height: 30px; padding: 0 12px; font-size: 14px; }
 
-.links { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
-.links a {
-    color: var(--accent);
-    border: 1px solid var(--line);
-    border-radius: 6px;
-    padding: 6px 10px;
-    text-decoration: none;
-    font-size: 13px;
-}
-.links a:hover { border-color: var(--accent); }
+.btn2 { background: var(--surface); color: var(--accent); }
+.btn2:hover { background: var(--accent-dark); color: #fbf3f3; }
 
-.input-block { border-top: 1px solid var(--line); padding-top: 12px; margin-top: 12px; }
+.btn-red { background: var(--danger); border-color: var(--danger); }
+.btn-red:hover { background: #961f09; border-color: #961f09; }
+
+/* список страниц портала */
+.pages { list-style: none; margin-top: 12px; }
+.pages li { padding: 5px 0; border-top: 1px solid var(--border); }
+.pages li:first-child { border-top: 0; }
+
+/* переключатель, как в портале */
+.toggle { margin-top: 12px; }
+.toggle input { display: none; }
+.toggle label { position: relative; display: block; padding-left: 48px; height: 24px; line-height: 26px; cursor: pointer; }
+.toggle label:before, .toggle label:after { display: block; position: absolute; content: ''; }
+.toggle label:before { width: 40px; height: 24px; left: 0; border-radius: 12px; background: var(--disabled); transition: .3s; }
+.toggle label:after { width: 20px; height: 20px; left: 2px; top: 2px; border-radius: 50%; background: #fff; transition: .3s; }
+.toggle input:checked + label:before { background: var(--accent); }
+.toggle input:checked + label:after { left: 18px; }
+
+/* входы */
+.input-block { border-top: 1px solid var(--border); padding-top: 12px; margin-top: 12px; }
 .input-block:first-child { border-top: 0; padding-top: 0; margin-top: 0; }
-.input-block h3 { margin: 0 0 8px; font-size: 14px; display: flex; align-items: center; gap: 8px; }
-.dot { width: 10px; height: 10px; border-radius: 50%; display: inline-block; }
-.dot.red { background: #e2574c; }
-.dot.blue { background: #4aa3df; }
+.circle { width: 14px; height: 14px; border-radius: 50%; background: var(--accent); }
+.circle.hot { background: var(--danger); }
 
 pre {
-    margin: 12px 0 0;
-    max-height: 340px;
+    margin-top: 12px;
+    max-height: 320px;
     overflow: auto;
-    background: #0d1319;
-    border: 1px solid var(--line);
-    border-radius: 6px;
+    background: var(--field);
+    border: 1px solid var(--border);
+    border-radius: 8px;
     padding: 12px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     font-size: 12px;
-    color: #b6c6d6;
+    line-height: 16px;
+    color: var(--text);
 }

--- a/simulator/src/sim/pult.js
+++ b/simulator/src/sim/pult.js
@@ -7,8 +7,8 @@
  */
 'use strict';
 
+/* Главная страница открывается кнопкой, остальные - списком под ней */
 var PORTAL_LINKS = [
-    { path: '/index.html', text: 'Главная' },
     { path: '/captive_portal_start.html', text: 'Мастер настройки' },
     { path: '/wifi_settings.html', text: 'Wi-Fi' },
     { path: '/input/1/setup.html', text: 'Вход 1 (синий)' },
@@ -17,7 +17,7 @@ var PORTAL_LINKS = [
     { path: '/alarms.html', text: 'Тревоги' },
     { path: '/about.html', text: 'О программе' },
     { path: '/logs.html', text: 'Логи' },
-    { path: '/reset.html', text: 'Сброс' },
+    { path: '/reset.html', text: 'Сброс к заводским' },
 ];
 
 var COUNTER_TYPES = [
@@ -92,11 +92,13 @@ function drawLinks() {
     var box = el('links');
     if (box.childElementCount) return;
     PORTAL_LINKS.forEach(function (link) {
+        var item = document.createElement('li');
         var a = document.createElement('a');
         a.href = link.path;
         a.target = 'waterius-portal';
         a.textContent = link.text;
-        box.appendChild(a);
+        item.appendChild(a);
+        box.appendChild(item);
     });
 }
 
@@ -107,13 +109,13 @@ function drawInputs() {
             var block = document.createElement('div');
             block.className = 'input-block';
             block.innerHTML =
-                '<h3><span class="dot ' + (input === 0 ? 'red' : 'blue') + '"></span>Вход ' + input +
+                '<h3><span class="circle' + (input === 0 ? ' hot' : '') + '"></span>Вход ' + input +
                 (input === 0 ? ' (красный)' : ' (синий)') + '</h3>' +
                 '<div class="row">' +
-                '<label>тип входа<select data-type="' + input + '"></select></label>' +
-                '<button data-impulse="' + input + '">+1 импульс</button>' +
-                '<label>серия<input type="number" data-count="' + input + '" value="10" min="1" max="1000"></label>' +
-                '<button class="ghost" data-series="' + input + '">Подать серию</button>' +
+                '<label class="field">тип входа<select data-type="' + input + '"></select></label>' +
+                '<button class="btn btn-sm" data-impulse="' + input + '">+1 импульс</button>' +
+                '<label class="field">серия<input type="number" data-count="' + input + '" value="10" min="1" max="1000"></label>' +
+                '<button class="btn btn-sm btn2" data-series="' + input + '">Подать серию</button>' +
                 '</div>' +
                 '<p class="note" data-info="' + input + '"></p>';
             box.appendChild(block);


### PR DESCRIPTION
Пульт был тёмной панелью «для разработчика» и рядом с порталом выглядел чужим. Теперь он в языке прошивки и личного кабинета — токены совпадают в обоих источниках:

| | значение |
|---|---|
| акцент | `#1655F5`, наведение `#06277B` |
| тревожный | `#F53410` |
| границы / поля | `#E6E9F1` / `#F3F6FE` |
| текст / приглушённый | `#232323` / `#5B7795` |
| шрифт, скругление | Roboto, 8px |

Переключатели — той же формы, что на страницах настройки, кружки входов — те же `.circle` и `.circle.hot`.

Стили портала не подключены напрямую: у него вёрстка под экран телефона (фиксированная колонка 360px, `user-select:none` на всём), а пульту нужна сетка карточек. Взяты токены и форма элементов — файл вышел компактным.

**Раздел «Портал»**: одна кнопка «Ватериус» ведёт на главную, остальные страницы — текстовым списком под ней. Пояснение про соседнюю вкладку убрано.

Смотреть после мержа: https://firmware-simulator.waterius.ru

🤖 Generated with [Claude Code](https://claude.com/claude-code)