### PR TITLE
Пульт берёт типы входа из селектора портала

### DIFF
--- a/simulator/gen_from_firmware.js
+++ b/simulator/gen_from_firmware.js
@@ -185,6 +185,24 @@ function fsInfo(dataDir) {
     return { totalBytes: FS_TOTAL, usedBytes: used };
 }
 
+/*
+Список типов входа снимается прямо с селектора портала: подписи в пульте обязаны
+совпадать со страницей, а не быть вторым набором слов про то же самое.
+*/
+function counterTypeOptions() {
+    const html = read(path.join(ESP, 'data/input_setup.html'));
+    const select = html.match(/<select[^>]*id="counter_type"[\s\S]*?<\/select>/);
+    if (!select) return [];
+
+    const options = [];
+    const re = /<option[^>]*value="(\d+)"[^>]*>([^<]+)<\/option>/g;
+    let m;
+    while ((m = re.exec(select[0])) !== null) {
+        options.push({ value: Number(m[1]), text: m[2].trim() });
+    }
+    return options;
+}
+
 function generate() {
     const defines = {};
     const enums = {};
@@ -223,6 +241,7 @@ function generate() {
         params,
         settings,
         valid_counter_types: validCounterTypes(enums),
+        counter_type_options: counterTypeOptions(),
         fs: fsInfo(path.join(ESP, 'data')),
     };
 }

--- a/simulator/src/index.html
+++ b/simulator/src/index.html
@@ -84,6 +84,7 @@
     </section>
 </main>
 
+<script src="/sim/generated.js"></script>
 <script src="/sim/pult.js"></script>
 </body>
 </html>

--- a/simulator/src/sim/pult.js
+++ b/simulator/src/sim/pult.js
@@ -20,14 +20,8 @@ var PORTAL_LINKS = [
     { path: '/reset.html', text: 'Сброс к заводским' },
 ];
 
-var COUNTER_TYPES = [
-    { value: 0, text: 'Механический' },
-    { value: 2, text: 'Электронный' },
-    { value: 4, text: 'Электронный (+)' },
-    { value: 5, text: 'Датчик протечки (замыкание)' },
-    { value: 6, text: 'Датчик протечки (размыкание)' },
-    { value: 255, text: 'Нет входа' },
-];
+/* Типы входа - те же, что в селекторе портала: снимаются с input_setup.html */
+var COUNTER_TYPES = (self.SIM_GENERATED && self.SIM_GENERATED.counter_type_options) || [];
 
 var WL_NAMES = {
     0: 'код 0 (idle)',

--- a/simulator/test_simulator.js
+++ b/simulator/test_simulator.js
@@ -145,6 +145,14 @@ function testGenerated() {
     if (sett.mqtt_port !== gen.defines.MQTT_DEFAULT_PORT) problems.push('умолчание mqtt_port не из прошивки');
     if (SimState.fieldLength('waterius_host') !== gen.defines.HOST_LEN) problems.push('длина waterius_host не из прошивки');
 
+    // Пульт выставляет типы входа этим списком, а прошивка их проверяет
+    if (!gen.counter_type_options.length) problems.push('не разобран селектор типа входа');
+    gen.counter_type_options.forEach((option) => {
+        if (!gen.valid_counter_types.includes(option.value)) {
+            problems.push('тип входа ' + option.value + ' есть в селекторе, но прошивка его не признаёт');
+        }
+    });
+
     check('таблицы сняты с исходников прошивки', problems);
 }
 


### PR DESCRIPTION
Хвост от #394: подписи типов входа в пульте симулятора были отдельным списком и разъехались со страницей — «Механический» вместо «Механический (Геркон, Намур)», «Нет входа» вместо «Выключен».

Список больше не пишется руками: генератор снимает его прямо с `<select id="counter_type">` в `ESP8266/data/input_setup.html`, пульт только рисует. Проверка в `test_simulator.js`: каждое значение из селектора обязано проходить `is_valid_counter_type` прошивки.