### PR TITLE
Симулятор — не портал: заголовок про устройство и пояснение красным

### DIFF
--- a/simulator/src/index.html
+++ b/simulator/src/index.html
@@ -3,12 +3,15 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Симулятор портала Ватериуса</title>
+    <title>Симулятор устройства Ватериус</title>
     <link rel="stylesheet" href="/sim/pult.css">
 </head>
 <body>
 <header>
-    <h1>Симулятор портала Ватериуса</h1>
+    <h1>Симулятор устройства Ватериус</h1>
+    <p class="about">Данный сайт является демонстрационной версией настройки wi-fi устройства
+        Ватериус. Т.е. то, что вы увидите во время настройки устройства вы можете увидеть
+        на этом сайте.</p>
     <p id="status" class="status">Запускаю симулятор…</p>
 </header>
 

--- a/simulator/src/sim/pult.css
+++ b/simulator/src/sim/pult.css
@@ -35,6 +35,8 @@ h1 { font-size: 20px; line-height: 28px; font-weight: 700; }
 h2 { font-size: 16px; line-height: 24px; font-weight: 700; margin-bottom: 12px; }
 h3 { font-size: 14px; font-weight: 700; margin-bottom: 8px; display: flex; align-items: center; gap: 8px; }
 
+.about { color: var(--danger); margin-top: 8px; max-width: 780px; }
+
 .status { color: var(--muted); font-size: 12px; line-height: 16px; margin-top: 4px; }
 .status.err { color: var(--danger); }
 


### PR DESCRIPTION
`firmware-simulator.waterius.ru` называл себя «Симулятор портала Ватериуса» — со стороны это читается как симулятор личного кабинета, а не как демонстрация настройки устройства.

- заголовок и `<title>` → **«Симулятор устройства Ватериус»**
- под заголовком красным (`--danger`, тот же #f53410, что у портала и ЛК): «Данный сайт является демонстрационной версией настройки wi-fi устройства Ватериус. Т.е. то, что вы увидите во время настройки устройства вы можете увидеть на этом сайте.»

Внутренние упоминания портала (карточка «Портал», кнопка «Обновить портал», комментарии в `sw.js`, README) не трогал — там это про captive-портал прошивки.

Проверки: `simulator/build.sh` собирается, `node simulator/test_simulator.js` и `node simulator/test_worker.js` — все проверки пройдены.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu3odEES5VDJS9indxyhcn