### PR TITLE
Стенд: снять xfail, дефекты исправлены

### DIFF
--- a/Utils/hil/README.md
+++ b/Utils/hil/README.md
@@ -102,20 +102,20 @@ def test_E1_flow_alarm(stand, quiet):
 звать `/pulse` (выдержка на плате) и откатывается на два запроса, если метода в
 клиенте нет; для ритмичных серий нужен `/pulse_train` на самой плате.
 
-## Известные дефекты прошивки
+## Что стенд нашёл
 
-Два теста помечены `xfail` — они написаны под правильное поведение и станут
-зелёными сами, когда дефект починят:
+Пять дефектов, ради которых он и писался. Все исправлены, и каждый закрыт
+тестом, который на сломанной прошивке падает:
 
-| Тест | Дефект |
-|---|---|
-| `test_E3a_single_pulse_is_not_a_leak` | [#405](https://github.com/dontsovcmc/waterius/issues/405): один импульс после долгой тишины поднимает ложную протечку, и она не снимается никогда (`Attiny85/src/alarm.h`, `prev_gap` после насыщения `ticks`) |
-| `test_D2b_undelivered_session_keeps_delta` | [#407](https://github.com/dontsovcmc/waterius/issues/407): точка отсчёта расхода двигается после подключения к Wi-Fi, а не после доставки: посылка не дошла — прирост потерян |
+| Дефект | Тест | Исправлено в |
+|---|---|---|
+| [#405](https://github.com/dontsovcmc/waterius/issues/405) один импульс после долгой тишины поднимал протечку, и она не снималась никогда | `test_E3a_single_pulse_is_not_a_leak` | attiny 42 |
+| [#406](https://github.com/dontsovcmc/waterius/issues/406) повторная отправка после применения настроек не уходила в брокер | `test_G1_all_three_channels` следит за `MQTT: Not connected` | ЕСП 2.0.47 |
+| [#407](https://github.com/dontsovcmc/waterius/issues/407) прирост терялся, если Wi-Fi поднялся, а посылка не дошла | `test_D2b_undelivered_session_keeps_delta` | ЕСП 2.0.47 |
+| [#408](https://github.com/dontsovcmc/waterius/issues/408) `mqtt_connect` возвращал успех после всех неудач | `test_G5_broker_unreachable` | ЕСП 2.0.47 |
+| [#409](https://github.com/dontsovcmc/waterius/issues/409) снятие retained-команды уходило без флага retain | `test_I7_retain_flag` | ЕСП 2.0.47 |
 
-Ещё три дефекта тесты обходят, а не проверяют. [#408](https://github.com/dontsovcmc/waterius/issues/408): `MQTT: Connecting failed` не
-печатается никогда (`mqtt_connect` возвращает успех после всех неудач), поэтому
-ловим `MQTT: Connect failed with state`. [#406](https://github.com/dontsovcmc/waterius/issues/406): повторная отправка после
-применения настроек не уходит в брокер, потому что `send_mqtt` закрывает
-соединение — `test_G1` следит за строкой `MQTT: Not connected`. [#409](https://github.com/dontsovcmc/waterius/issues/409):
-снятие retained-команды публикуется без флага retain при выключенной настройке
-`mqtt_retain`.
+**Минимальные версии для полного прогона: attiny 42, ЕСП 2.0.47.** На attiny 41
+падает `test_E3a`, на ЕСП 2.0.46 и старше - `test_D2b`, `test_G5` и часть
+проверок MQTT. Это верный результат, а не поломка стенда: прошивка на стенде
+должна быть той, которую собираетесь выпускать.

--- a/Utils/hil/test_alarms.py
+++ b/Utils/hil/test_alarms.py
@@ -76,19 +76,22 @@ def test_E2_flow_alarm_clears(stand: Stand, quiet: None, slow_clock: None) -> No
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(reason='#405: ложная протечка от одного импульса после долгой тишины')
 def test_E3a_single_pulse_is_not_a_leak(stand: Stand, quiet: None,
                                         slow_clock: None) -> None:
     """
     Негативный контроль для непрерывного расхода.
 
     Один импульс и тишина - это не протечка. Тест существует потому, что без
-    него проверка ритма зеленеет на сломанной логике: прошивка поднимает
-    ALARM_LEAK и при полном отсутствии расхода, если перед импульсом была
-    достаточно длинная пауза (Attiny85/src/alarm.h, prev_gap).
+    него проверка ритма зеленеет на сломанной логике: пауза перед импульсом не
+    должна запоминаться как ритм, иначе ALARM_LEAK поднимается при полном
+    отсутствии расхода (#405, Attiny85/src/alarm.h, ALARM_MAX_GAP_MIN).
+
+    Требует attiny 42: на 41 тест падает, и это верный результат.
     """
-    stand.setup_alarms(channel=1, factor=FACTOR, alarm_leak=LEAK_MINUTES,
-                       ctype=NAMUR, vacation=0)
+    setup = stand.setup_alarms(channel=1, factor=FACTOR, alarm_leak=LEAK_MINUTES,
+                               ctype=NAMUR, vacation=0)
+    assert (setup.attiny_version or 0) >= 42, (
+        f'нужна attiny 42, на стенде {setup.attiny_version}')
     stand.reset_observers()
 
     stand.dut.pulse(channel=1, count=1)

--- a/Utils/hil/test_meter.py
+++ b/Utils/hil/test_meter.py
@@ -66,14 +66,12 @@ def test_D2a_missed_session_keeps_consumption(stand: Stand, slow_clock: None) ->
 
 
 @pytest.mark.slow
-@pytest.mark.xfail(reason='#407: точка отсчёта двигается после коннекта, а не после доставки')
 def test_D2b_undelivered_session_keeps_delta(stand: Stand, slow_clock: None) -> None:
     """
     Тот же опыт, но сеть жива, а получатели недоступны.
 
-    Ожидаем то же самое: прирост не должен теряться от того, что посылка не
-    доехала. Сейчас `update_config` сдвигает точку отсчёта сразу после
-    подключения к Wi-Fi, поэтому расход первого периода пропадает.
+    Прирост не теряется от того, что посылка не доехала: точка отсчёта
+    двигается после доставки, а не после подключения к Wi-Fi (#407).
     """
     stand.setup(channel=1, factor=FACTOR, ctype=NAMUR, period_min=120)
     stand.reset_observers()

--- a/Utils/hil/test_sending.py
+++ b/Utils/hil/test_sending.py
@@ -122,9 +122,10 @@ def test_G5_broker_unreachable(stand: Stand) -> None:
     """
     Брокер недоступен, облако живо: четыре вспышки.
 
-    Ловим `MQTT: Connect failed with state`, а не `MQTT: Connecting failed`:
-    вторая строка не печатается никогда, потому что mqtt_connect возвращает
-    успех после всех неудачных попыток.
+    Проверяем обе строки. `MQTT: Connect failed with state` печатается на
+    каждой попытке, `MQTT: Connecting failed` - один раз, когда попытки
+    исчерпаны: до #408 эта ветка была недостижима, и сеанс по логу выглядел
+    так, будто подключение удалось.
     """
     stand.reset_observers()
 
@@ -134,4 +135,5 @@ def test_G5_broker_unreachable(stand: Stand) -> None:
 
     session.assert_cause('mqtt')
     assert 'MQTT: Connect failed with state' in session.text
+    assert 'MQTT: Connecting failed' in session.text
     assert session.confirm and session.confirm['waterius'] == SEND_OK


### PR DESCRIPTION
Хвост после вливания #410–#414. Стенд ([#404](https://github.com/dontsovcmc/waterius/pull/404)) писался тогда, когда пять дефектов ещё были живы: два теста стояли под `xfail`, третий обходил дефект вместо того, чтобы его проверять.

## Что изменилось

**`xfail` сняты.** `test_E3a_single_pulse_is_not_a_leak` (#405, исправлено в attiny 42) и `test_D2b_undelivered_session_keeps_delta` (#407, ЕСП 2.0.47) написаны под правильное поведение и теперь должны проходить.

**`test_G5` стал прямой проверкой #408.** Строка `MQTT: Connecting failed` раньше не печаталась никогда — ветка была недостижима, потому что `mqtt_connect` возвращал успех после всех неудач. Тест ловил только `MQTT: Connect failed with state`; теперь требует обе строки.

**`test_E3a` проверяет версию attiny.** На 41 он падает по существу дефекта, и без явного сообщения это выглядело бы поломкой стенда:

```
нужна attiny 42, на стенде 41
```

**README.** Раздел «Известные дефекты прошивки» заменён на «Что стенд нашёл»: пять дефектов, каким тестом каждый закрыт, в какой версии исправлен. Плюс явно названы минимальные версии для полного прогона — **attiny 42, ЕСП 2.0.47**.

## Проверка

```
python3 -m pytest Utils/hil -q          # 7 passed, 30 skipped (без --stand)
python3 -m pytest Utils/hil --collect-only -q   # 37 tests collected
```

Тесты на живом железе прогнать не могу — нужен стенд.

🤖 Generated with [Claude Code](https://claude.com/claude-code)