### PR TITLE
Стенд: после портала ждать тишины, а не первого конца сеанса

### DIFF
--- a/Utils/hil/logwatch.py
+++ b/Utils/hil/logwatch.py
@@ -459,10 +459,14 @@ class LogWatcher:
             m = RE_MODE.search(line)
             if m:
                 if mode is not None and int(m.group(1)) != mode:
-                    # Не тот сеанс: выбрасываем его целиком, чтобы не мешал
+                    # Не тот сеанс: выбрасываем его целиком, чтобы не мешал.
+                    # В журнал он всё-таки попадает: тест, ждущий сеанса, что
+                    # именно устройство делало вместо него, иначе не расскажет.
                     end = self._find_end(i)
                     if end is None:
                         return None
+                    logger.info(f'пропускаем сеанс mode={m.group(1)}, '
+                                f'ждём mode={mode}')
                     del self.lines[:end + 1]
                     return self._take_session(mode)
                 start = i

--- a/Utils/hil/stand.py
+++ b/Utils/hil/stand.py
@@ -164,6 +164,29 @@ class Stand:
         logger.info(f'сеанс: mode={session.mode}, посылок {len(session.payloads)}')
         return session
 
+    def wait_asleep(self, timeout: float = 60.0) -> bool:
+        """
+        Дождаться, пока устройство уснёт: строки `Going to sleep`.
+
+        Одного конца сеанса мало. Из режима настройки прошивка уходит
+        перезапуском, и такой сеанс кончается не сном, а следующим включением -
+        ЕСП после него доигрывает обычный сеанс и только тогда засыпает. Пока
+        она запитана, нажатие кнопки до attiny не доходит, и тест, начавшийся в
+        это время, нажал бы впустую и ждал бы своего сеанса до таймаута.
+
+        Перезапуск с передачей укладывается в десяток секунд; минуты хватает с
+        запасом, а сеанс, не кончившийся за неё, не кончится вовсе - через две
+        минуты attiny снимет питание молча (`WAIT_ESP_MSEC`).
+        """
+        while True:
+            session = self.log.wait_session(timeout)
+            if session is None:
+                logger.warning(f'устройство не уснуло за {timeout:.0f} с')
+                return False
+            logger.info(f'доиграл сеанс mode={session.mode}')
+            if session.complete:
+                return True
+
     def expect_no_session(self, timeout: float, mode: int | None = None) -> None:
         assert self.log.expect_no_session(timeout, mode), (
             f'ожидали тишину {timeout:.0f} с (mode={mode}), но сеанс состоялся\n'

--- a/Utils/hil/test_portal.py
+++ b/Utils/hil/test_portal.py
@@ -64,6 +64,9 @@ def board(cfg: Any, stand: Any) -> Iterator[AtBoard]:
         except Exception as err:
             logger.warning(f'портал не закрылся командой: {err}')
         device.close()
+        # Пока устройство не уснуло, ЕСП запитана, и нажатие кнопки до attiny
+        # не доходит: соседний тест нажал бы впустую.
+        stand.wait_asleep()
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
## Что чинит

Тест `G1_all_three_channels` падал в общем прогоне и проходил в одиночку — наводка соседа, а не дефект прошивки.

Механика, найденная по секундам в логе:

1. Из режима настройки прошивка уходит **перезапуском**. Тот сеанс кончается не сном, а следующим включением, и сразу за ним ЕСП доигрывает обычный сеанс (`mode=3`).
2. Фикстура портала отдавала управление по первому концу сеанса — то есть пока ЕСП ещё запитана.
3. Следующий тест первым делом чистит буфер лога и стирает начало доигрывающего сеанса, а потом жмёт кнопку.
4. До attiny такое нажатие не доходит: ЕСП уже запитана. Тест ждёт своего сеанса до таймаута и падает — при том, что в логе виден целый успешный сеанс. Отчёт выглядит абсурдно: «сеанса не было», а ниже полный сеанс с `Going to sleep`.

## Правки

- `test_portal.py`: фикстура ждёт строку засыпания (`Session.complete`) — только она означает, что питание с ЕСП снято и кнопка снова работает. Не таймаут и не окно тишины: доигрывающий сеанс кончается сам, ждать после него нечего.
- `logwatch.py`: сеанс не того режима больше не выбрасывается молча, а пишет `пропускаем сеанс mode=X, ждём mode=Y`. Без этой строки «сеанса не было» и «был, но не тот» неразличимы в отчёте, а разбираются по-разному.

## Проверка

Стенд, ЕСП 2.0.47 (собрана из `dev`), attiny 38.

Пара «портал, затем G1» — фикстура выходит ровно на засыпании доигрывающего сеанса, простоя нет:

```
23:26:37 после портала доиграл сеанс mode=1
23:26:42 после портала доиграл сеанс mode=3
23:26:54 сеанс: mode=3, посылок 1
2 passed, 63 deselected in 56.50s
```

Весь быстрый набор:

```
41 passed, 10 skipped, 14 deselected in 866.79s (0:14:26)
```

Пропущены только тесты, которым нужна attiny 41. До правки в том же наборе падал `G1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)